### PR TITLE
Add LastSaaS Admin MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [pydantic/logfire-mcp](https://github.com/pydantic/logfire-mcp) ⭐ <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Access to OpenTelemetry traces and metrics
 - [seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/go/go-original-wordmark.svg" width="16" height="16"/> 🏠 - System monitoring for CPU, memory, disk, and network
 - [automatikstudio/sitescore-mcp](https://github.com/automatikstudio/sitescore-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Website analysis and SEO scoring for performance optimization
+- [jonradoff/lastsaas](https://github.com/jonradoff/lastsaas) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/go/go-original-wordmark.svg" width="16" height="16"/> ☁️ - Read-only admin MCP server for SaaS platforms with 26 tools for dashboards, users, tenants, financials, logs, and health monitoring
 
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 


### PR DESCRIPTION
## Summary

- Adds [LastSaaS](https://github.com/jonradoff/lastsaas) to the Monitoring section
- Read-only admin MCP server for SaaS platforms with 26 tools covering dashboards, users, tenants, financials, logs, and health monitoring
- Written in Go, cloud-deployed