### PR TITLE
Add Xquik X/Twitter MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [adhikasp/mcp-twikit](https://github.com/adhikasp/mcp-twikit) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Interact with Twitter search and timeline
 - [elie222/inbox-zero](https://github.com/elie222/inbox-zero/tree/main/apps/mcp-server) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Email management with follow-up detection
 - [AbdelStark/nostr-mcp](https://github.com/AbdelStark/nostr-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Nostr protocol integration for posting notes
+- [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - X/Twitter data platform — MCP server, 76 REST API endpoints, 20 extraction tools
 
 ### 🖥️ <a name="developer-tools"></a>Developer Tools
 


### PR DESCRIPTION
Add [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) to the Communication section.

Xquik is an X/Twitter data platform with an MCP server, 76 REST API endpoints, and 20 extraction tools.

Disclosure: I am the developer of Xquik.