### PR TITLE
Add operant-mcp — security testing server with 51 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,11 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [automatikstudio/reviewreply-mcp](https://github.com/automatikstudio/reviewreply-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Customer review management and response generation
 - [Humanizer PRO](https://github.com/khadinakbaronline/humanizer-pro-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> - Transforms AI-generated text into natural, human-sounding content with stealth, academic, and SEO modes. Includes AI detection scanning. [Website](https://texthumanizer.pro)
 
+### 🔒 <a name="security"></a>Security
+
+- [operantlabs/operant-mcp](https://github.com/operantlabs/operant-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment
+
+
 ## Frameworks
 
 - [hannesrudolph/fastmcp](https://github.com/hannesrudolph/fastmcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> - Python framework for building MCP servers with FastAPI


### PR DESCRIPTION
## Summary

Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) with a new **Security** section.

**operant-mcp** is a security testing MCP server with 51 tools covering:
- Penetration testing (SQL injection, XSS, SSRF, command injection, etc.)
- Network forensics (PCAP analysis, DNS analysis, TLS inspection)
- Memory analysis (Linux/Windows volatility, rootkit detection)
- Vulnerability assessment (file upload testing, deserialization, GraphQL introspection)

Install via `npx operant-mcp`.

## Changes

- Added a new Security section with operant-mcp entry in README.md