### PR TITLE
Add operant-mcp to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [rishikavikondala/mcp-server-aws](https://github.com/rishikavikondala/mcp-server-aws) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Perform operations on AWS resources
 - [Vortiago/mcp-azure-devops](https://github.com/Vortiago/mcp-azure-devops) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Bridge to Azure DevOps services
 - [TencentEdgeOne/edgeone-pages-mcp](https://github.com/TencentEdgeOne/edgeone-pages-mcp) <img src="https://edgeone.ai/favicon.ico" width="16" height="16"/> 🏠 - An MCP service for deploying HTML content to EdgeOne Pages and obtaining a publicly accessible URL.
+- [operantlabs/operant-mcp](https://github.com/operantlabs/operant-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment
 
 ### 📊 <a name="monitoring"></a>Monitoring
 


### PR DESCRIPTION
## Summary
- Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the Developer Tools section
- Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment
- TypeScript, MIT license, runs locally