### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [calclavia/mcp-obsidian](https://github.com/calclavia/mcp-obsidian) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Read and search through your Obsidian vault or any directory containing Markdown notes
 - [vivekVells/mcp-pandoc](https://github.com/vivekVells/mcp-pandoc) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> 🏠 - Seamless document format conversion using Pandoc, supporting Markdown, HTML, PDF, DOCX, CSV and more
 - [connerlambden/bgpt-mcp](https://github.com/connerlambden/bgpt-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" width="16" height="16"/> ☁️ - Search scientific papers with structured experimental data (methods, results, sample sizes, quality scores) extracted from full-text studies
+- [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> 🏠 ☁️ - State-of-the-art long-term memory for AI agents with built-in MCP server, supporting semantic, graph, and temporal retrieval strategies
 
 ### 🗺️ <a name="location-services"></a>Location Services
 


### PR DESCRIPTION
## Summary

- Adds [Hindsight](https://github.com/vectorize-io/hindsight) to the **Knowledge & Memory** section
- Hindsight is a state-of-the-art long-term memory system for AI agents by [Vectorize](https://vectorize.io), featuring a built-in MCP server
- Open source (MIT license), supports semantic, graph, BM25, and temporal retrieval strategies
- Can run fully self-hosted via `pip install hindsight-all` or in the cloud

## Why it fits this list

Hindsight includes a native MCP server enabled by default, making it a natural addition to this awesome MCP servers list. It provides persistent long-term memory capabilities that AI agents can access through the standard MCP protocol.