### PR TITLE
Add prompt-to-asset to Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [automatikstudio/reviewreply-mcp](https://github.com/automatikstudio/reviewreply-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Customer review management and response generation
 - [Humanizer PRO](https://github.com/khadinakbaronline/humanizer-pro-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> - Transforms AI-generated text into natural, human-sounding content with stealth, academic, and SEO modes. Includes AI detection scanning. [Website](https://texthumanizer.pro)
 - [MohamedAbdallah-14/prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Generate production-ready visual assets (app icons, favicons, OG images, logos) by routing prompts across 30+ image generation models
-- [MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Claude Code plugin and CLI that strips AI writing patterns (sycophantic openers, stock vocabulary, hedging) from output before publishing
 
 ## Frameworks
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [automatikstudio/remixpost-mcp](https://github.com/automatikstudio/remixpost-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Social media content remixing and cross-platform optimization
 - [automatikstudio/reviewreply-mcp](https://github.com/automatikstudio/reviewreply-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Customer review management and response generation
 - [Humanizer PRO](https://github.com/khadinakbaronline/humanizer-pro-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> - Transforms AI-generated text into natural, human-sounding content with stealth, academic, and SEO modes. Includes AI detection scanning. [Website](https://texthumanizer.pro)
+- [MohamedAbdallah-14/prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Generate production-ready visual assets (app icons, favicons, OG images, logos) by routing prompts across 30+ image generation models
+- [MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Claude Code plugin and CLI that strips AI writing patterns (sycophantic openers, stock vocabulary, hedging) from output before publishing
 
 ## Frameworks
 


### PR DESCRIPTION
Adding one open-source MCP server to the Utilities section.

**prompt-to-asset**
MCP server that generates production-ready visual assets (app icons, favicons, OG images, logos, wordmarks) by routing prompts across 30+ image generation models. Three execution modes: inline SVG, external prompt, full API generation. Zero API key required for first run via Pollinations and Stable Horde free tiers.
- npm: `prompt-to-asset`
- Repo: https://github.com/MohamedAbdallah-14/prompt-to-asset