### PR TITLE
Add TWZRD Agent Intel - Solana x402 remote MCP server for agent trust scoring

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -192,6 +192,7 @@ Une liste sélectionnée de serveurs Model Context Protocol (MCP) exceptionnels.
 - [bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp/) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - API Bankless Onchain pour les contrats intelligents
 - [GoPlausible/algorand-mcp](https://github.com/GoPlausible/algorand-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Outils complets pour interagir avec la blockchain Algorand
 
+- [twzrd-sol/twzrd-agent-intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Notation de confiance des agents Solana via micropaiements x402 — vérifications préliminaires on-chain gratuites et reçus de confiance signés payants réglés en moins d'une seconde sur intel.twzrd.xyz/mcp
 ### 🛠️ <a name="utilitaires"></a>Utilitaires
 
 - [modelcontextprotocol/server-pdf](https://github.com/modelcontextprotocol/server-pdf) ⭐ <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Manipulation et extraction de PDF

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [GoPlausible/algorand-mcp](https://github.com/GoPlausible/algorand-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Comprehensive tools for interacting with Algorand blockchain
 - [hive-intel/hive-crypto-mcp](https://github.com/hive-intel/hive-crypto-mcp) - Hive Intelligence: Ultimate cryptocurrency MCP for AI assistants with unified access to crypto, DeFi, and Web3 analytics. Hive's remote mcp server guide [remote server](https://hiveintelligence.xyz/crypto-mcp).
 
+- [twzrd-sol/twzrd-agent-intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Solana-native agent trust scoring via x402 micropayments — free on-chain preflight checks and paid signed trust receipts settled in under 1 second at intel.twzrd.xyz/mcp
 ### 🛠️ <a name="utilities"></a>Utilities
 
 - [githejie/mcp-server-calculator](https://github.com/githejie/mcp-server-calculator) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> 🏠 - Calculator for precise numerical calculations


### PR DESCRIPTION
## Summary

- Adds **TWZRD Agent Intel** to the `### 💰 Finance` section (both English and French READMEs)
- A Solana-native remote MCP server providing agent trust scoring via x402 micropayments
- Free on-chain preflight checks + paid signed V5 trust receipts settled in <1 second
- Live endpoint: `https://intel.twzrd.xyz/mcp` (Streamable-HTTP, no setup required)
- Source: https://intel.twzrd.xyz

## Entry added

```
- [twzrd-sol/twzrd-agent-intel](...) 🐍 ☁️ - Solana-native agent trust scoring via x402 micropayments — free on-chain preflight checks and paid signed trust receipts settled in under 1 second at intel.twzrd.xyz/mcp
```

No setup required — connect at `intel.twzrd.xyz/mcp`.