### PR TITLE
Add The Stall MCP — 210 pay-per-call capabilities via x402 (Finance section, v4.63.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp/) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Bankless Onchain API for smart contracts
 - [GoPlausible/algorand-mcp](https://github.com/GoPlausible/algorand-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Comprehensive tools for interacting with Algorand blockchain
 - [hive-intel/hive-crypto-mcp](https://github.com/hive-intel/hive-crypto-mcp) - Hive Intelligence: Ultimate cryptocurrency MCP for AI assistants with unified access to crypto, DeFi, and Web3 analytics. Hive's remote mcp server guide [remote server](https://hiveintelligence.xyz/crypto-mcp).
+- [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - 205 pay-per-call MCP capabilities covering finance, crypto/DeFi, prediction markets, weather, and research data. Agents pay USDC micropayments via x402 protocol on Base — no API keys required.
 
 ### 🛠️ <a name="utilities"></a>Utilities
 


### PR DESCRIPTION
## The Stall MCP Server

Adds [The Stall](https://github.com/thebrierfox/the-stall) to the **Finance** section of mcp-hub.

### What it is

A pay-per-call MCP server with **210 capabilities** covering equity markets, crypto, DeFi, options analysis, macro intelligence, and more. No API key or subscription required — agents pay USDC micropayments per call via the x402 protocol on Base.

### Key capabilities

- **Market data:** `us-stock-price`, `us-stock-history`, `market-gex` (dealer GEX via CBOE), `options-chain`, `options-snapshot`
- **Crypto/DeFi:** `defillama-pack`, `defi-state-pack`, `dex-swap-quote`, `crypto-momentum-pack`
- **Intelligence:** `congressional-trades`, `sec-insider-trades`, `fomc-tracker`, `macro-indicators`, `polymarket-intel`
- **Total:** 210 capabilities priced $0.001 – $0.35/call

### Links

- **Endpoint:** https://the-stall.intuitek.ai/mcp
- **GitHub:** https://github.com/thebrierfox/the-stall
- **Version:** v4.63.3 | 210 capabilities
- **Glama listing:** https://glama.ai/mcp/servers/@thebrierfox/the-stall