### PR TITLE
Add AccInt MCP memory server

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 ### 🧠 <a name="knowledge--memory"></a>Knowledge & Memory
 
 - [modelcontextprotocol/server-memory](https://github.com/modelcontextprotocol/server-memory) ⭐ <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Knowledge graph-based persistent memory system
+- [maxbaluev/accreted-intelligence](https://github.com/maxbaluev/accreted-intelligence) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/rust/rust-plain.svg" width="16" height="16"/> 🏠 - Local-first work memory for coding agents with scored retrieval, commitment tracking, and outcome-based credit across sessions
 - [CheMiguel23/MemoryMesh](https://github.com/CheMiguel23/MemoryMesh) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Enhanced graph-based memory for AI role-play
 - [topoteretes/cognee](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> 🏠 - Memory manager with various graph and vector stores
 - [hannesrudolph/mcp-ragdocs](https://github.com/hannesrudolph/mcp-ragdocs) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> 🏠 - Documentation retrieval through vector search


### PR DESCRIPTION
## Summary

Adds AccInt to the Knowledge & Memory section as a local-first MCP memory server for coding agents.

AccInt provides scored retrieval, commitment tracking, and outcome-based credit so coding agents can reuse lessons across sessions. The public repository contains the installer, docs, MCP/plugin integration glue, and release artifacts; the engine binary is currently private, so the entry is intentionally phrased around the MCP surface and local-first behavior rather than claiming the core engine is fully open source.

## Validation

- `git diff --check`
- `https://github.com/maxbaluev/accreted-intelligence` returns HTTP 200
- `https://accint.xyz/` returns HTTP 200