### PR TITLE
Add FilingFirehose MCP to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [thebrierfox/the-stall](https://github.com/thebrierfox/the-stall) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - 205 pay-per-call MCP capabilities covering finance, crypto/DeFi, prediction markets, weather, and research data. Agents pay USDC micropayments via x402 protocol on Base — no API keys required.
 
 - [twzrd-sol/twzrd-agent-intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Solana-native agent trust scoring via x402 micropayments — free on-chain preflight checks and paid signed trust receipts settled in under 1 second at intel.twzrd.xyz/mcp
+- [FilingFirehose](https://filingfirehose.com/mcp) ☁️ - Hosted SEC EDGAR MCP for any US ticker — 8-K body-text parsing, 10-K / 10-Q / S-3 / 13D reads, forensic risk scores (LOW/MODERATE/ELEVATED/HIGH), and cyber-incident tracking. Remote endpoint at https://filingfirehose.com/mcp
 ### 🛠️ <a name="utilities"></a>Utilities
 
 - [githejie/mcp-server-calculator](https://github.com/githejie/mcp-server-calculator) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> 🏠 - Calculator for precise numerical calculations


### PR DESCRIPTION
Adds [FilingFirehose](https://filingfirehose.com) to the Finance section.

FilingFirehose is a hosted MCP server exposing SEC EDGAR filings (8-K, 10-K, 10-Q, S-3, 13D), forensic risk scores (LOW/MODERATE/ELEVATED/HIGH), and cyber-incident tracking on any US stock ticker. Complements the existing crypto-heavy Finance entries by covering US equity disclosure intelligence. No install — clients connect via `https://filingfirehose.com/mcp`.