### PR TITLE
Add ZeroPointRepo/youtube-mcp under Web & Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [BuyWhere](https://github.com/BuyWhere/buywhere-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Real-time product search and price comparison across 260K+ products from Lazada, Shopee, FairPrice, Courts, and other Southeast Asia merchants. Free API key at [buywhere.ai/api-keys](https://buywhere.ai/api-keys). Published as `@buywhere/mcp-server`
 - [mcp/aws-kb-retrieval-server](https://hub.docker.com/r/mcp/aws-kb-retrieval-server) ⭐ <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - MCP server for retrieving information from the AWS Knowledge Base using the Bedrock Agent Runtime
 - [pranciskus/newsmcp](https://github.com/pranciskus/newsmcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
+- [ZeroPointRepo/youtube-mcp](https://github.com/ZeroPointRepo/youtube-mcp) ☁️ - YouTube transcripts, video and channel search, channel browsing, within channel search, and playlist extraction for AI agents. Remote MCP server at [transcriptapi.com/mcp](https://transcriptapi.com/mcp), Bearer key or OAuth 2.1 sign in.
 
 ### 🔄 <a name="version-control"></a>Version Control
 


### PR DESCRIPTION
Adds `ZeroPointRepo/youtube-mcp` to **🌐 Web & Search**.

**What it is:** an MIT licensed MCP server for YouTube content. Six tools: get a video transcript, search YouTube for videos or channels, list a channel's uploads, search within a channel, get a channel's latest uploads, and list every video in a playlist. Returns clean JSON or markdown.

**Why Web & Search:** it is a vertical search and retrieval source, the same shape as the Airbnb, ShopSavvy, BuyWhere and news entries already in that section. It is distinct from `anaisbetts/mcp-youtube` in Utilities, which fetches subtitles only and has no search, channel or playlist tooling.

**Details:**
- Hosted remote MCP endpoint at https://transcriptapi.com/mcp, so ☁️ and no language icon (the repo carries the manifests and docs, not a local runtime)
- Auth is a Bearer API key or OAuth 2.1 with Dynamic Client Registration, so Claude and ChatGPT can register themselves
- New accounts get a free credit allowance with no card required
- Entry matches the existing row format and is a one line addition to README.md only

**Disclosure:** I maintain this server and the TranscriptAPI backend behind it. Happy to move the entry to Utilities or shorten the description if you prefer.
