### PR TITLE
Add Pocket Drives to Location Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 - [KyrieTangSheng/mcp-server-nationalparks](https://github.com/KyrieTangSheng/mcp-server-nationalparks) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Up-to-date information on U.S. National Parks details, alerts, visitor centers, campgrounds, hiking trails, and events
 - [r-huijts/ns-mcp-server](https://github.com/r-huijts/ns-mcp-server) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Access to Dutch Railways (NS) real-time travel information and disruptions via the official NS API
 - [r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Interface with the Rijksmuseum API to search artworks, retrieve details, access image tiles, and explore collections
+- [RevList/pocket-drives-mcp](https://github.com/RevList/pocket-drives-mcp) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg" width="16" height="16"/> ☁️ - Search peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app. Remote at https://pocketdrives.ai/mcp
 
 ### 🎮 <a name="gaming"></a>Gaming
 


### PR DESCRIPTION
Adds Pocket Drives under Location Services, after rijksmuseum and before Gaming.

Pocket Drives is a remote MCP for searching peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app. Streamable HTTP at https://pocketdrives.ai/mcp. Listing repo: https://github.com/RevList/pocket-drives-mcp. Official registry: `ai.pocketdrives/pocket-drives`.

PocketList Inc builds the platform. Hosts are independent operators (not a Pocket-owned fleet).