### PR TITLE
Add Wine Labs MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 
 - [twzrd-sol/twzrd-agent-intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Solana-native agent trust scoring via x402 micropayments — free on-chain preflight checks and paid signed trust receipts settled in under 1 second at intel.twzrd.xyz/mcp
 - [FilingFirehose](https://filingfirehose.com/mcp) ☁️ - Hosted SEC EDGAR MCP for any US ticker — 8-K body-text parsing, 10-K / 10-Q / S-3 / 13D reads, forensic risk scores (LOW/MODERATE/ELEVATED/HIGH), and cyber-incident tracking. Remote endpoint at https://filingfirehose.com/mcp
+- [Wine Labs](https://github.com/imiraoui/winelabs-mcp) ☁️ - Fine-wine identity matching, pricing, auction and exchange research, merchant comparisons, portfolios, and cellar workflows. Hosted Streamable HTTP at `https://chat.wine-labs.com/mcp` with browser OAuth.
 ### 🛠️ <a name="utilities"></a>Utilities
 
 - [githejie/mcp-server-calculator](https://github.com/githejie/mcp-server-calculator) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> 🏠 - Calculator for precise numerical calculations

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ A curated list of awesome Model Context Protocol (MCP) servers.
 
 - [twzrd-sol/twzrd-agent-intel](https://github.com/twzrd-sol/wzrd-final/tree/main/packages/twzrd-agent-intel) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> ☁️ - Solana-native agent trust scoring via x402 micropayments — free on-chain preflight checks and paid signed trust receipts settled in under 1 second at intel.twzrd.xyz/mcp
 - [FilingFirehose](https://filingfirehose.com/mcp) ☁️ - Hosted SEC EDGAR MCP for any US ticker — 8-K body-text parsing, 10-K / 10-Q / S-3 / 13D reads, forensic risk scores (LOW/MODERATE/ELEVATED/HIGH), and cyber-incident tracking. Remote endpoint at https://filingfirehose.com/mcp
-- [Wine Labs](https://github.com/imiraoui/winelabs-mcp) ☁️ - Fine-wine identity matching, pricing, auction and exchange research, merchant comparisons, portfolios, and cellar workflows. Hosted Streamable HTTP at `https://chat.wine-labs.com/mcp` with browser OAuth.
+- [Wine Labs](https://winelabs.ai/agents) ☁️ - Fine-wine identity matching, pricing, auction and exchange research, merchant comparisons, portfolios, and cellar workflows. Hosted Streamable HTTP at `https://chat.wine-labs.com/mcp` with browser OAuth. [Public metadata](https://github.com/imiraoui/winelabs-mcp).
 ### 🛠️ <a name="utilities"></a>Utilities
 
 - [githejie/mcp-server-calculator](https://github.com/githejie/mcp-server-calculator) <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" width="16" height="16"/> 🏠 - Calculator for precise numerical calculations


### PR DESCRIPTION
## Summary

- Adds the official Wine Labs hosted MCP server to Finance.
- Documents the Streamable HTTP endpoint and browser OAuth accurately.
- Links the canonical [Wine Labs MCP product page](https://winelabs.ai/agents) while retaining public connection metadata and installation documentation.

## Verification

- Public MCP endpoint returns the expected OAuth challenge.
- OAuth protected-resource discovery, product, install, privacy, and terms URLs return HTTP 200.

This is a maintainer self-submission prepared with an automated coding agent.